### PR TITLE
Skip usbmuxd setup for wireless (portless) devices

### DIFF
--- a/files/start_all.sh
+++ b/files/start_all.sh
@@ -104,32 +104,47 @@ fi
 #### Prepare for iOS
 if [[ "$PLATFORM_NAME" == "ios" ]]; then
   #### Connect usbmuxd
-  wait_usbmuxd_start_time=$(date +%s)
-  socketCreated=0
-  # Parse usbmuxd host and port ( 'appium:22' -> 'appium 22' )
-  IFS=: read -r USBMUXD_SOCKET_HOST USBMUXD_SOCKET_PORT <<< "$USBMUXD_SOCKET_ADDRESS"
+  #
+  # WIRELESS=true marks a device with no usb path -- an Apple TV 4K, for example,
+  # which has no diagnostic port and is reached over a network tunnel owned by the
+  # host. There is no usbmuxd socket to share for such a device, so this whole block
+  # is skipped. Without the skip the loop below burns USBMUXD_SOCKET_TIMEOUT and then
+  # exits 1, and the container never reaches the WDA check that would have succeeded.
+  #
+  # Nothing after this block needs usbmuxd: the WDA health check is plain HTTP
+  # against WDA_HOST/WDA_PORT, and STF registration uses --serial ${DEVICE_UDID}
+  # from the environment. Set by zebrunner/mcloud-agent for rows with wireless=true.
+  if [[ "${WIRELESS:-false}" == "true" ]]; then
+    echo "WIRELESS=true: skipping usbmuxd setup, this device has no usb path."
+    echo "WebDriverAgent is expected at http://${WDA_HOST}:${WDA_PORT} (published by the host)."
+  else
+    wait_usbmuxd_start_time=$(date +%s)
+    socketCreated=0
+    # Parse usbmuxd host and port ( 'appium:22' -> 'appium 22' )
+    IFS=: read -r USBMUXD_SOCKET_HOST USBMUXD_SOCKET_PORT <<< "$USBMUXD_SOCKET_ADDRESS"
 
-  while [[ $(( wait_usbmuxd_start_time + $USBMUXD_SOCKET_TIMEOUT )) -gt "$(date +%s)" ]]; do
-    # Check connection
-    check_tcp_connection "$USBMUXD_SOCKET_HOST $USBMUXD_SOCKET_PORT"
-    if [[ $? -eq 0 ]]; then
-      # start socat client and connect to appium usbmuxd socket
-      rm -f /var/run/usbmuxd
-      socat UNIX-LISTEN:/var/run/usbmuxd,fork,reuseaddr,mode=777 TCP:${USBMUXD_SOCKET_ADDRESS} &
-      timeout 10 bash -c 'until [[ -S /var/run/usbmuxd ]]; do sleep 1; echo "/var/run/usbmuxd socket existence check"; done'
+    while [[ $(( wait_usbmuxd_start_time + $USBMUXD_SOCKET_TIMEOUT )) -gt "$(date +%s)" ]]; do
+      # Check connection
+      check_tcp_connection "$USBMUXD_SOCKET_HOST $USBMUXD_SOCKET_PORT"
       if [[ $? -eq 0 ]]; then
-        socketCreated=1
-        break
+        # start socat client and connect to appium usbmuxd socket
+        rm -f /var/run/usbmuxd
+        socat UNIX-LISTEN:/var/run/usbmuxd,fork,reuseaddr,mode=777 TCP:${USBMUXD_SOCKET_ADDRESS} &
+        timeout 10 bash -c 'until [[ -S /var/run/usbmuxd ]]; do sleep 1; echo "/var/run/usbmuxd socket existence check"; done'
+        if [[ $? -eq 0 ]]; then
+          socketCreated=1
+          break
+        fi
+      else
+        echo "Can't establish connection to usbmuxd socket [$USBMUXD_SOCKET_ADDRESS], one more attempt in $USBMUXD_SOCKET_PERIOD seconds."
       fi
-    else
-      echo "Can't establish connection to usbmuxd socket [$USBMUXD_SOCKET_ADDRESS], one more attempt in $USBMUXD_SOCKET_PERIOD seconds."
-    fi
-    sleep "$USBMUXD_SOCKET_PERIOD"
-  done
+      sleep "$USBMUXD_SOCKET_PERIOD"
+    done
 
-  if [[ $socketCreated -eq 0 ]]; then
-    echo "ERROR! usbmuxd socket not created"
-    exit 1
+    if [[ $socketCreated -eq 0 ]]; then
+      echo "ERROR! usbmuxd socket not created"
+      exit 1
+    fi
   fi
 
   #### Check {WDA}/status endpoint


### PR DESCRIPTION
## Problem

The iOS branch of `files/start_all.sh` unconditionally establishes a usbmuxd socat client from `USBMUXD_SOCKET_ADDRESS`, and `exit 1`s if it cannot.

A portless device such as an Apple TV 4K has no usbmuxd path at all, so the loop burns `USBMUXD_SOCKET_TIMEOUT` and the container dies **before reaching the WDA check that would have succeeded** — that check is plain HTTP.

## Change

Skip the usbmuxd block when `WIRELESS=true`. Nothing after it needs usbmuxd:

- the WDA readiness check is `curl http://${WDA_HOST}:${WDA_PORT}/status`
- STF registration passes `--serial ${DEVICE_UDID}` from the environment, not from device discovery
- `--wda-host ${WDA_HOST}` is already parameterised

`WIRELESS` defaults to `false`, so unset or false takes the existing path unchanged.

## Verification

`WIRELESS=true` skips; `WIRELESS=false` and unset both take the usbmuxd path.

Verified end to end on an Apple TV 4K (`AppleTV14,1`) on tvOS 18.4 and 26.6.


---

## Companion PRs — all three land together

These are one change split across three repos. Reviewed in isolation, PRs 2 and 3 look like no-ops: they consume the `WIRELESS=true` that PR 1 sets.

| Order | Repo | PR | Change |
|---|---|---|---|
| 1 | `mcloud-agent` | zebrunner/mcloud-agent#414 | honour the `wireless` device-list field; sets `WIRELESS=true`, `WDA_HOST`, `WDA_PORT` |
| 2 | `mcloud-device` | zebrunner/mcloud-device#210 | skip usbmuxd setup when `WIRELESS=true` |
| 3 | `appium` | zebrunner/appium#439 | skip usbmuxd setup in `ios.sh` when `WIRELESS=true` |

**Suggested merge order: 2 and 3 first, then 1.** The two consumers are inert until a device row sets `wireless=true`, so merging them ahead of PR 1 carries no behaviour change at all. Merging PR 1 first would leave a window where a `wireless=true` row starts containers whose images still insist on usbmuxd.

Every row without `wireless=true` behaves exactly as it does today, in all three repos.
